### PR TITLE
fixed MessagingSystem.Control.SetConcurrentHandlers()

### DIFF
--- a/src/SevenDigital.Messaging.Integration.Tests/Api/ConcurrencyLimit.cs
+++ b/src/SevenDigital.Messaging.Integration.Tests/Api/ConcurrencyLimit.cs
@@ -26,15 +26,15 @@ namespace SevenDigital.Messaging.Integration.Tests
 		[Test]
 		public void concurrency_limit_is_obeyed_in_default_mode ()
 		{
+			MessagingSystem.Control.SetConcurrentHandlers(10);
 			MessagingSystem.Configure.WithDefaults().SetIntegrationTestMode();
-			MessagingSystem.Control.SetConcurrentHandlers(1);
 
 			CountingHandler.Reset();
 			MessagingSystem.Receiver().Listen(_=>_
 				.Handle<IMessage>().With<CountingHandler>()
 			);
 
-			for (int i = 0; i < 20; i++)
+			for (int i = 0; i < 200; i++)
 			{
 				MessagingSystem.Sender().SendMessage(new GreenMessage());
 			}
@@ -43,7 +43,7 @@ namespace SevenDigital.Messaging.Integration.Tests
 				Thread.Sleep(250);
 			}
 			MessagingSystem.Control.Shutdown();
-			Assert.That(CountingHandler.MaxCount, Is.EqualTo(1));
+			Assert.That(CountingHandler.MaxCount, Is.EqualTo(10));
 		}
 		public class CountingHandler:IHandle<IMessage>
 		{

--- a/src/SevenDigital.Messaging/ConfigurationActions/SDM_Control.cs
+++ b/src/SevenDigital.Messaging/ConfigurationActions/SDM_Control.cs
@@ -70,9 +70,8 @@ namespace SevenDigital.Messaging.ConfigurationActions
 			if (max < 1) throw new ArgumentException("Concurrent handlers must be at least 1", "max");
 
 			var controller = ObjectFactory.TryGetInstance<IReceiver>() as IReceiverControl;
-			if (controller == null) throw new InvalidOperationException("Messaging is not configured");
-
-			controller.SetConcurrentHandlers(max);
+			if (controller != null)
+				controller.SetConcurrentHandlers(max);
 			MessagingSystem.Concurrency = max;
 		}
 

--- a/src/SevenDigital.Messaging/MessageReceiving/ReceiverNode.cs
+++ b/src/SevenDigital.Messaging/MessageReceiving/ReceiverNode.cs
@@ -43,8 +43,7 @@ namespace SevenDigital.Messaging.MessageReceiving
 
 			_receivingDispatcher = dispatchFactory.Create(
 				_pollingNode,
-				new ThreadedWorkerPool<IPendingMessage<object>>("SDMessaging_Receiver")
-				);
+				new ThreadedWorkerPool<IPendingMessage<object>>("SDMessaging_Receiver", MessagingSystem.Concurrency));
 
 			_receivingDispatcher.AddConsumer(HandleIncomingMessage);
 			_receivingDispatcher.SetMaximumInflight(MessagingSystem.Concurrency);
@@ -57,7 +56,7 @@ namespace SevenDigital.Messaging.MessageReceiving
 		{
 			var shouldStart = false;
 			foreach (var binding in bindings.AllBindings())
-			{	
+			{
 				shouldStart = true;
 				Type messageType = binding.Item1, handlerType = binding.Item2;
 


### PR DESCRIPTION
allow MessagingSystem.Control.SetConcurrentHandlers() to be used before MessagingSystem.Configure

modified ReceiverNode to configure ThreadedWorkerPool with thread count specified by SetConcurrentHandlers()
